### PR TITLE
Bump version and fix download URL

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - make.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [not linux]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/pierrehirel/{{ name }}/archive/refs/tags/Beta-{{ version }}.tar.gz
+  url: https://github.com/pierrehirel/{{ name }}/archive/Beta-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - make.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "atomsk" %}
-{% set version = "0.11" %}
-{% set sha256 = "cc248af89ebd32d117caed2490b5fface1fa894652875f2a36a398aa0904cc76" %}
+{% set version = "0.11.1" %}
+{% set sha256 = "ffaca24f371ba228cbf1e37cebd4e8de34660f44c1a54894bfb2eeb05e30f598" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/pierrehirel/{{ name }}/archive/Beta-{{ version }}.tar.gz
+  url: https://github.com/pierrehirel/{{ name }}/archive/refs/tags/Beta-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - make.patch


### PR DESCRIPTION
Previous URL was `https://github.com/pierrehirel/{{ name }}/archive/Beta-{{ version }}.tar.gz`, but the download link on the github page[1][2] actually points to `https://github.com/pierrehirel/{{ name }}/archive/refs/tags/Beta-{{ version }}.tar.gz`.  I'm not sure if that changed recently or not, but I suppose it's safer to go with the URL publicly shown.

[1]: https://github.com/pierrehirel/atomsk/releases
[2]: https://github.com/pierrehirel/atomsk/tags

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
